### PR TITLE
Fix undefined array keys in disposes

### DIFF
--- a/application/models/Query_model.php
+++ b/application/models/Query_model.php
@@ -129,8 +129,9 @@ class Query_model extends CI_Model {
             return true;
         }
         if($param1=="adminQueryDisposesAll"){
-            $this->db->select('*');
+            $this->db->select('transaction.*, disposes.gadget_type, disposes.quantity');
             $this->db->from('transaction');
+            $this->db->join('disposes', 'disposes.transaction_id = transaction.transaction_id', 'left');
             $this->db->order_by('transaction_id','desc');
             return $this->db->get()->result_array();
         }
@@ -168,8 +169,9 @@ class Query_model extends CI_Model {
         // All other admin disposes queries do NOT filter hidden
         if($param1=="adminApprovedQueryDisposes"){
             $where=array("payment_status"=>1);
-            $this->db->select('*');
+            $this->db->select('transaction.*, disposes.gadget_type, disposes.quantity');
             $this->db->from('transaction');
+            $this->db->join('disposes', 'disposes.transaction_id = transaction.transaction_id', 'left');
             $this->db->where($where);
             $this->db->order_by('transaction_id','desc');
             return $this->db->get()->result_array();
@@ -177,8 +179,9 @@ class Query_model extends CI_Model {
         }//end
         if($param1=="adminPendingQueryDisposes"){
             $where=array("payment_status"=>0);
-            $this->db->select('*');
+            $this->db->select('transaction.*, disposes.gadget_type, disposes.quantity');
             $this->db->from('transaction');
+            $this->db->join('disposes', 'disposes.transaction_id = transaction.transaction_id', 'left');
             $this->db->where($where);
             $this->db->order_by('transaction_id','desc');
             return $this->db->get()->result_array();

--- a/application/views/backend/collector/disposes.php
+++ b/application/views/backend/collector/disposes.php
@@ -51,8 +51,8 @@ defined('BASEPATH') OR exit('No direct script access allowed');
                   <td><?php echo $i++; ?>.</td>
                   <td><?php echo $dispose['transaction_code']; ?></td>
                   <td><?php echo $dispose['name']; ?></td>
-                  <td><?php echo $dispose['gadget_type']; ?></td>
-                  <td><?php echo $dispose['quantity']; ?></td>
+                  <td><?php echo isset($dispose['gadget_type']) ? $dispose['gadget_type'] : 'N/A'; ?></td>
+                  <td><?php echo isset($dispose['quantity']) ? $dispose['quantity'] : 'N/A'; ?></td>
                   <td>₱<?php echo number_format($dispose['transaction_total'], 2); ?></td>
                   <td>
                     <?php if($dispose['payment_status'] == 1): ?>
@@ -127,8 +127,8 @@ defined('BASEPATH') OR exit('No direct script access allowed');
                   <td><?php echo $i++; ?>.</td>
                   <td><?php echo $dispose['transaction_code']; ?></td>
                   <td><?php echo $dispose['name']; ?></td>
-                  <td><?php echo $dispose['gadget_type']; ?></td>
-                  <td><?php echo $dispose['quantity']; ?></td>
+                  <td><?php echo isset($dispose['gadget_type']) ? $dispose['gadget_type'] : 'N/A'; ?></td>
+                  <td><?php echo isset($dispose['quantity']) ? $dispose['quantity'] : 'N/A'; ?></td>
                   <td>₱<?php echo number_format($dispose['transaction_total'], 2); ?></td>
                   <td><?php echo date('M d, Y', strtotime($dispose['collection_date'])); ?></td>
                   <td>
@@ -187,8 +187,8 @@ defined('BASEPATH') OR exit('No direct script access allowed');
                   <td><?php echo $i++; ?>.</td>
                   <td><?php echo $dispose['transaction_code']; ?></td>
                   <td><?php echo $dispose['name']; ?></td>
-                  <td><?php echo $dispose['gadget_type']; ?></td>
-                  <td><?php echo $dispose['quantity']; ?></td>
+                  <td><?php echo isset($dispose['gadget_type']) ? $dispose['gadget_type'] : 'N/A'; ?></td>
+                  <td><?php echo isset($dispose['quantity']) ? $dispose['quantity'] : 'N/A'; ?></td>
                   <td>₱<?php echo number_format($dispose['transaction_total'], 2); ?></td>
                   <td><?php echo date('M d, Y', strtotime($dispose['collection_date'])); ?></td>
                   <td>


### PR DESCRIPTION
Fix "Undefined array key" errors for gadget type and quantity on dispose listings.

The `gadget_type` and `quantity` fields are stored in the `disposes` table, not the `transaction` table. This PR updates the `Query_model` to `LEFT JOIN` the `disposes` table and adds `isset()` checks in the view to prevent errors when these fields are not present.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c8685d9-2327-4cf1-9596-fea515946495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c8685d9-2327-4cf1-9596-fea515946495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

